### PR TITLE
Change example code for DefaultComparer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ class Entity : EquatableBase<Entity>
 {
     static Entity()
     {
-        DefaultComparer =
+        EquatableBase<Entity>.DefaultComparer =
             EqualityComparerBuilder.For<Entity>()
                                    .EquateBy(e => e.Id);
     }
+    
+    public static new IFullEqualityComparer<Entity> DefaultComparer => EquatableBase<Entity>.DefaultComparer;
 
     public int Id { get; }
 }


### PR DESCRIPTION
In the example code for `EquatableBase<T>` declare a DefaultComparer property in the derived type to make sure that the static constructor has run. This will prevent users from getting null when using DerivedType.DefaultComparer (as I have repeatedly).